### PR TITLE
Moved variablesToPass to Begin

### DIFF
--- a/fixes.Tests.ps1
+++ b/fixes.Tests.ps1
@@ -227,7 +227,7 @@ describe "Invoke-IssueFix" {
     }
 
     function Test-Echo {
-        [CmdletBinding(SupportsShouldProcess=$false,DefaultParameterSetName="example")]
+        [CmdletBinding()]
         Param(
             [Parameter(Mandatory=$true)]
             [String]$Param1
@@ -237,11 +237,20 @@ describe "Invoke-IssueFix" {
             echo "$Param1"
         }
     }
-    $fix = New-IssueFix -FixCommand {Test-Echo} -FixDescription "DefaultParameterValues" -CheckName "Greetings"
 
+    $fix = New-IssueFix -FixCommand {Test-Echo} -FixDescription "DefaultParameterValues" -CheckName "Greetings"
     it "should use passed DefaultParameterValues" {
         $fix = $fix | Invoke-IssueFix -DefaultParameterValues @{"Test-Echo:Param1" = "Hi"}
         $fix.fixResults | Should be "Hi"
+    }
+
+    [PSObject[]] $fixes = $null
+    $fixes += New-IssueFix -FixCommand {Test-Echo} -FixDescription "DefaultParameterValues 1" -CheckName "Greetings"
+    $fixes += New-IssueFix -FixCommand {Test-Echo} -FixDescription "DefaultParameterValues 2" -CheckName "Greetings"
+
+    it "should use passed DefaultParameterValues with multiple fixes" {
+        $fixes = $fixes | Invoke-IssueFix -DefaultParameterValues @{"Test-Echo:Param1" = "Hi"}
+        $fixes.fixResults | Should be @("Hi", "Hi")
     }
 }
 

--- a/fixes.psm1
+++ b/fixes.psm1
@@ -704,6 +704,11 @@ function Invoke-IssueFix {
                 if ($NoNewScope) {
                         Write-Warning "Parameter switch NoNewScope is no longer supported, all invokes are in a child scope."
                 }
+
+                $variablesToPass = New-Object System.Collections.Generic.List[System.Management.Automation.PSVariable]
+                if ($DefaultParameterValues) {
+                        $variablesToPass.Add((New-Variable -Name "PSDefaultParameterValues" -Value $DefaultParameterValues -PassThru))
+                }
         }
 	Process {
                 #Make sure we got a fix passed
@@ -712,10 +717,6 @@ function Invoke-IssueFix {
                                 if ($PSCmdlet.ShouldProcess("Invoke $($Fix.fixDescription) from $($Fix.checkName) by running $($Fix.fixCommand)?")) {
                                         Add-Member -InputObject $Fix -MemberType NoteProperty -Name "fixResults" -Value "" -Force
                                         try {
-                                                $variablesToPass = New-Object System.Collections.Generic.List[System.Management.Automation.PSVariable]
-                                                if ($DefaultParameterValues) {
-                                                        $variablesToPass.Add((New-Variable -Name "PSDefaultParameterValues" -Value $DefaultParameterValues -PassThru))
-                                                }
                                                 $Fix.fixResults = [String] ($fix.fixCommand.InvokeWithContext(@{}, $variablesToPass))
                                                 $Fix.status = 2 #Complete
                                                 $Fix.notificationCount = 1


### PR DESCRIPTION
The error was generated by trying to add to the variable array multiple times.  By moving the variablesToPass construct to the Begin closure, eliminated the error.  Closes #13 