### PR TITLE
Added Scheduled status and ScheduledAfter attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The IssueFix object contains:
 + checkName (String)
 + fixCommand (ScriptBlock)
 + fixDescription (String)
-+ status (Int) Ready | Pending | Complete | Error | Canceled
++ status (Int) Ready | Pending | Complete | Error | Canceled | Hold | Scheduled
 + fixResults (String)
 + notificationCount (Int)
++ scheduledAfter (DateTime)
 + databasePath (string) Add/updated by Read/Write-IssueCheck if saved to a database folder.
 + path (string) Add/updated by Read/Write-IssueCheck if saved as a standalone file.
 + creationDateTime (DateTime) Date and time when the fix object is created.
@@ -113,6 +114,9 @@ The scheduled job will:
 3) Archive-IssueFix fixes that have completed or errored, perhaps based on the notificationCount.
 
 Users then recieve the the notification and can review both ezecuted fixes and "Pendong" fixes.  The user can use fix cmdlets to change the status of pending fixes which will then be processed at the next scheduled Invoke.
+
+### Scheduled Status
+Do not confuse the concept of scheduling invokes with the Scheduled status.  The Scheduled status behaves similar to Ready status except the Invoke-IssueFix cmdlet also checks the scheduledAfter fix attribute and verifies it is in the past before invoking.
 
 # Use Cases
 Detect system irregularities or failures.  Check coukd be to ping one or more systems.  If a system doesn't respond a fix could be generated in the "Pending" state to just provide notice or maybe the fix is a command to restart something.  Notification count could be set high so users keep getting the notice.

--- a/Tests/fixes.Tests.ps1
+++ b/Tests/fixes.Tests.ps1
@@ -175,6 +175,10 @@ describe "Set-IssueFix" {
         $fix = New-IssueFix -FixCommand {Write-Output "Hello World"} -FixDescription "First fix" -CheckName "Greetings" -Status Pending
         ($fix | Set-IssueFix -Status Hold).status | should be Hold
     }
+    it "should change the Status of the IssueFix to Scheduled" {
+        $fix = New-IssueFix -FixCommand {Write-Output "Hello World"} -FixDescription "First fix" -CheckName "Greetings" -Status Pending
+        ($fix | Set-IssueFix -Status Scheduled).status | should be Scheduled
+    }
 
     it "should change the NofiticationCount of the IssueFix" {
         $fix = New-IssueFix -FixCommand {Write-Output "Hello World"} -FixDescription "First fix" -CheckName "Greetings"
@@ -184,6 +188,12 @@ describe "Set-IssueFix" {
     it "should change the SequenceNumber of the IssueFix" {
         $fix = New-IssueFix -FixCommand {Write-Output "Hello World"} -FixDescription "First fix" -CheckName "Greetings"
         ($fix | Set-IssueFix -SequenceNumber 66).sequenceNumber | should be 66
+    }
+
+    it "should change the ScheduledAfter of the IssueFix" {
+        $fix = New-IssueFix -FixCommand {Write-Output "Hello World"} -FixDescription "First fix" -CheckName "Greetings"
+        $futureDate = ((Get-Date).AddDays(2))
+        ($fix | Set-IssueFix -ScheduledAfter $futureDate).scheduledAfter | should be $futureDate
     }
 
     it "should change the NofiticationCount of the IssueFix by 1" {
@@ -227,6 +237,15 @@ describe "Invoke-IssueFix" {
     it "should invoke again as Force is set" {
         Start-Sleep -Seconds 5
         $fix = $fix | Invoke-IssueFix -Force
+        $fix.statusDateTime | should not be  $lastD
+    }
+
+    $lastD = $fix.statusDateTime
+
+    it "should invoke again as Status is Scheduled and ScheduledDate is set to yesterday" {
+        Start-Sleep -Seconds 5
+        $fix = $fix | Set-IssueFix -Status Scheduled -ScheduledAfter (Get-Date).AddDays(-1)
+        $fix = $fix | Invoke-IssueFix
         $fix.statusDateTime | should not be  $lastD
     }
 

--- a/Tests/fixes.Tests.ps1
+++ b/Tests/fixes.Tests.ps1
@@ -237,17 +237,25 @@ describe "Invoke-IssueFix" {
     it "should invoke again as Force is set" {
         Start-Sleep -Seconds 5
         $fix = $fix | Invoke-IssueFix -Force
-        $fix.statusDateTime | should not be  $lastD
+        $fix.statusDateTime | should not be $lastD
     }
-
-    $lastD = $fix.statusDateTime
 
     it "should invoke again as Status is Scheduled and ScheduledDate is set to yesterday" {
-        Start-Sleep -Seconds 5
         $fix = $fix | Set-IssueFix -Status Scheduled -ScheduledAfter (Get-Date).AddDays(-1)
+        $lastD = $fix.statusDateTime
+        Start-Sleep -Seconds 5
         $fix = $fix | Invoke-IssueFix
-        $fix.statusDateTime | should not be  $lastD
+        $fix.statusDateTime | should not be $lastD
     }
+
+    it "should not invoke again even though status is Scheduled but ScheduledAfter is in the future" {
+        $fix = $fix | Set-IssueFix -Status Scheduled -ScheduledAfter (Get-Date).AddDays(1)
+        $lastD = $fix.statusDateTime
+        Start-Sleep -Seconds 5
+        $fix = $fix | Invoke-IssueFix
+        $fix.statusDateTime | should be $lastD
+    }
+
 
     $fix = New-IssueFix -FixCommand {Write-Output (5 / 0)} -FixDescription "First error" -CheckName "Greetings"
 


### PR DESCRIPTION
Added a Scheduled status and a ScheduledAfter attribute to the issue fix object.  By default the ScheduledAfter attribute defaults to current date/time.  Besides changes to the New, Write, Read and Set cmdlets, changes were made to the Invoke-IssueFix cmdlet to invoke fixes where status is Scheduled and ScheduledAfter is in the past.

resolves #19 